### PR TITLE
Skip modules with an empty path.

### DIFF
--- a/jlcpcba_main.py
+++ b/jlcpcba_main.py
@@ -202,11 +202,17 @@ def create_pcba():
     botfh.write("Designator,Val,Package,Mid X,Mid Y,Rotation,Layer\n")
 
     for m in board.GetModules():
+        if not m.GetPath() or m.GetPath().isspace():
+            continue
+
         #uid = m.GetPath().replace('/', '')
 	# Need to just pull out the non-zero part at the end
-	uid = m.GetPath().AsString().lower()
-	while (uid[0] in "0/-"):
-		uid = uid[1:]
+        if isinstance(m.GetPath(), str):
+            uid = m.GetPath().lower()
+        else:
+            uid = m.GetPath().AsString().lower()
+        while (uid[0] in "0/-"):
+                uid = uid[1:]
 
         smd = ((m.GetAttributes() & pcbnew.MOD_CMS) == pcbnew.MOD_CMS)
         x = m.GetPosition().x/1000000.0


### PR DESCRIPTION
I was getting errors on the path -> uid parsing logic. I'm not sure why
one of the modules had an empty path, but with this change I still get
the correct number of components in the position file.

Also fix a few errants tabs that should be spaces.